### PR TITLE
feat: Switch to Alpine for final image to minimize size.

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,11 +42,11 @@ Fill in the `.env.example` file with your configuration. Or you can create any o
 Build the image
 
 ```bash
-docker build --build-arg CONFIG_FILE=.env.example -t deskcard-next .
+docker build -t deskcard-next .
 ```
 
 Run the container
 
 ```bash
-docker run -d -p 3000:3000 deskcard-next
+docker run -d -p 3000:3000 --env-file .env.example deskcard-next
 ```


### PR DESCRIPTION
The Debian-slim image size was 408 MB; switching to Alpine reduces it to 342 MB. Additionally, configuration files have been removed from the build process. Environment variables will be used instead, either through an env file or set during runtime.